### PR TITLE
Matchable instances, plus needed version bump of tagsoup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,13 +19,6 @@
     - [Latest version](http://www.w3.org/TR/selectors4/)
 
 
-## StringLike
-
-* Add instances for
-    - `Data.ByteString.ByteString`
-    - `Data.ByteString.Lazy.ByteString`
-
-
 ## Selection
 
 * Handle case-insensitivity (<http://www.w3.org/TR/selectors/#casesens>)

--- a/TODO.md
+++ b/TODO.md
@@ -24,8 +24,6 @@
 * Add instances for
     - `Data.ByteString.ByteString`
     - `Data.ByteString.Lazy.ByteString`
-    - `Data.Text.Text`
-    - `Data.Text.Lazy.Text`
 
 
 ## Selection

--- a/src/Text/StringLike/Matchable.hs
+++ b/src/Text/StringLike/Matchable.hs
@@ -8,6 +8,8 @@ module Text.StringLike.Matchable (
 
 import Data.List
 import Text.StringLike
+import qualified Data.Text as Text.Strict
+import qualified Data.Text.Lazy as Text.Lazy
 
 
 {- |
@@ -41,6 +43,20 @@ instance Matchable String where
     matchesInfixOf  = checkNull null isInfixOf
     matchesSuffixOf = checkNull null isSuffixOf
     matchesWordOf   = \s -> any (`matchesExactly` s) . splitOn (`elem` " \t\n\r")
+
+
+instance Matchable Text.Strict.Text where
+    matchesPrefixOf = checkNull Text.Strict.null Text.Strict.isPrefixOf
+    matchesInfixOf  = checkNull Text.Strict.null Text.Strict.isInfixOf
+    matchesSuffixOf = checkNull Text.Strict.null Text.Strict.isSuffixOf
+    matchesWordOf   = \s -> any (`matchesExactly` s) . Text.Strict.split (`elem` " \t\n\r")
+
+
+instance Matchable Text.Lazy.Text where
+    matchesPrefixOf = checkNull Text.Lazy.null Text.Lazy.isPrefixOf
+    matchesInfixOf  = checkNull Text.Lazy.null Text.Lazy.isInfixOf
+    matchesSuffixOf = checkNull Text.Lazy.null Text.Lazy.isSuffixOf
+    matchesWordOf   = \s -> any (`matchesExactly` s) . Text.Lazy.split (`elem` " \t\n\r")
 
 
 -- | @checkNull null comp s1 s2@ returns 'False' if either @null s1 == True@ or @comp s1 s2 == False@,

--- a/src/Text/StringLike/Matchable.hs
+++ b/src/Text/StringLike/Matchable.hs
@@ -10,6 +10,8 @@ import Data.List
 import Text.StringLike
 import qualified Data.Text as Text.Strict
 import qualified Data.Text.Lazy as Text.Lazy
+import qualified Data.ByteString.Char8 as BS.Strict
+import qualified Data.ByteString.Lazy.Char8 as BS.Lazy
 
 
 {- |
@@ -57,6 +59,22 @@ instance Matchable Text.Lazy.Text where
     matchesInfixOf  = checkNull Text.Lazy.null Text.Lazy.isInfixOf
     matchesSuffixOf = checkNull Text.Lazy.null Text.Lazy.isSuffixOf
     matchesWordOf   = \s -> any (`matchesExactly` s) . Text.Lazy.split (`elem` " \t\n\r")
+
+
+instance Matchable BS.Strict.ByteString where
+    matchesPrefixOf = checkNull BS.Strict.null BS.Strict.isPrefixOf
+    matchesInfixOf  = checkNull BS.Strict.null BS.Strict.isInfixOf
+    matchesSuffixOf = checkNull BS.Strict.null BS.Strict.isSuffixOf
+    matchesWordOf   = \s -> any (`matchesExactly` s) . BS.Strict.splitWith (`elem` " \t\n\r")
+
+
+instance Matchable BS.Lazy.ByteString where
+    matchesPrefixOf = checkNull BS.Lazy.null BS.Lazy.isPrefixOf
+    -- NB: BS.Lazy does not export @isInfixOf@.
+    -- Workaround is to convert to strict.
+    matchesInfixOf  = checkNull BS.Lazy.null (\a b -> BS.Strict.isInfixOf (BS.Lazy.toStrict a) (BS.Lazy.toStrict b))
+    matchesSuffixOf = checkNull BS.Lazy.null BS.Lazy.isSuffixOf
+    matchesWordOf   = \s -> any (`matchesExactly` s) . BS.Lazy.splitWith (`elem` " \t\n\r")
 
 
 -- | @checkNull null comp s1 s2@ returns 'False' if either @null s1 == True@ or @comp s1 s2 == False@,

--- a/tagsoup-selection.cabal
+++ b/tagsoup-selection.cabal
@@ -37,7 +37,9 @@ Library
                         parsec     >= 3.1.3  && < 3.2,
                         tagsoup    >= 0.13.3 && < 0.15,
                         -- TODO: Expand text lower bound?
-                        text       == 1.2.*
+                        text       == 1.2.*,
+                        -- TODO: Expand bytestring lower bound?
+                        bytestring == 0.10.*
 
 Source-Repository head
   Type:                 git

--- a/tagsoup-selection.cabal
+++ b/tagsoup-selection.cabal
@@ -35,7 +35,9 @@ Library
   Build-Depends:        base       >= 4.2    && < 5,
                         containers >= 0.3    && < 0.6,
                         parsec     >= 3.1.3  && < 3.2,
-                        tagsoup    >= 0.13.3 && < 0.15
+                        tagsoup    >= 0.13.3 && < 0.15,
+                        -- TODO: Expand text lower bound?
+                        text       == 1.2.*
 
 Source-Repository head
   Type:                 git

--- a/tagsoup-selection.cabal
+++ b/tagsoup-selection.cabal
@@ -35,7 +35,7 @@ Library
   Build-Depends:        base       >= 4.2    && < 5,
                         containers >= 0.3    && < 0.6,
                         parsec     >= 3.1.3  && < 3.2,
-                        tagsoup    >= 0.13.3 && < 0.14
+                        tagsoup    >= 0.13.3 && < 0.15
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
Added instances of `Matchable` to the strict and lazy variants of `Text` and `ByteString`. Also, `tagsoup`'s newest version was out of bounds, so I bumped that.